### PR TITLE
Use 'npm ci' instead of 'npm i' in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - run: npm i
+      - run: npm ci
       - uses: changesets/action@master
         with:
           version: npm run version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - run: npm i
+      - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
This is part of #42.